### PR TITLE
Add ssl support to mongodump.

### DIFF
--- a/pipelinewise/fastsync/commons/tap_mongodb.py
+++ b/pipelinewise/fastsync/commons/tap_mongodb.py
@@ -298,6 +298,9 @@ class FastSyncTapMongoDB:
         if self.connection_config.get('replica_set', None) is not None:
             url += f'&replicaSet={self.connection_config["replica_set"]}'
 
+        if self.connection_config.get('ssl', None) is not None:
+            url += f'&ssl={self.connection_config["ssl"]}'
+
         return_code = subprocess.call([
             'mongodump',
             '--uri', f'"{url}"',

--- a/tests/units/fastsync/commons/test_fastsync_tap_mongodb.py
+++ b/tests/units/fastsync/commons/test_fastsync_tap_mongodb.py
@@ -24,7 +24,8 @@ class TestFastSyncTapMongoDB(TestCase):
                                   'user': 'my_user',
                                   'password': 'secret',
                                   'auth_database': 'admin',
-                                  'database': 'my_db'
+                                  'database': 'my_db',
+                                  'ssl': 'true'
                                   }
         self.mongo = FastSyncTapMongoDB(self.connection_config,
                                         lambda x: {
@@ -90,7 +91,7 @@ class TestFastSyncTapMongoDB(TestCase):
             call_mock.assert_called_once_with([
                 'mongodump',
                 '--uri', '"mongodb://my_user:secret@foo.com:3306/my_db'
-                         '?authSource=admin&readPreference=secondaryPreferred"',
+                         '?authSource=admin&readPreference=secondaryPreferred&ssl=true"',
                 '--forceTableScan',
                 '--gzip',
                 '-c', 'my_col',
@@ -134,7 +135,7 @@ class TestFastSyncTapMongoDB(TestCase):
                         call_mock.assert_called_once_with([
                             'mongodump',
                             '--uri', '"mongodb://my_user:secret@foo.com:3306/my_db'
-                                     '?authSource=admin&readPreference=secondaryPreferred"',
+                                     '?authSource=admin&readPreference=secondaryPreferred&ssl=true"',
                             '--forceTableScan',
                             '--gzip',
                             '-c', 'my_col',


### PR DESCRIPTION
## Problem

- The ssl option is not taken into account when using mongodump which results in hanging connection.

## Proposed changes

Take the `ssl` value from connection config into account when using `mongodump`. The same value is already used here https://github.com/transferwise/pipelinewise/blob/5b8e9fa80f620179a21777ea427114f0ace4be48/pipelinewise/fastsync/commons/tap_mongodb.py#L123


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
